### PR TITLE
Refactor checkpoint path handling in full SFT

### DIFF
--- a/pipeline/safe_llm_finetune/fine_tuning/methods/supervised_full_fine_tuning.py
+++ b/pipeline/safe_llm_finetune/fine_tuning/methods/supervised_full_fine_tuning.py
@@ -13,32 +13,44 @@ from safe_llm_finetune.fine_tuning.base import (
 
 class FullFineTuning(FineTuningMethod):
     """Trainiert alle Gewichte (kein PEFT)."""
+
     def __init__(self, model_adapter):
         super().__init__(model_adapter, "full")
         self.logger = logging.getLogger(__name__)
-        
+
     def get_name(self):
         return self.training_method
-        
-    def train(self, dataset_processor, config: TrainingConfig):
+
+    def train(self, dataset_processor, config: TrainingConfig, base_path: Path):
+        """Train the entire model without PEFT.
+
+        Args:
+            dataset_processor: DatasetProcessor instance providing the training data
+            config (TrainingConfig): Training configuration containing checkpoint settings
+            base_path (Path): Base path used to format the checkpoint directory
+        """
+
         self.logger.info("Starting full fine-tuning preparations...")
-        
+
         # 1) Datensatz holen
         ds = dataset_processor.get_sft_dataset()
 
         # 2) Modell & Tokenizer laden
         model = self.model_adapter.load_model()
-        tokenizer = self.model_adapter.load_tokenizer()
-        #model.gradient_checkpointing_enable() #disabled for more GPU Ram usage
+        _ = self.model_adapter.load_tokenizer()
+        # model.gradient_checkpointing_enable() #disabled for more GPU Ram usage
 
         # 3) Alle Trainings-Parameter extrahieren
         sft_kwargs = config.as_dict().copy()
         # report_to entfernen, wir fügen es gleich separat wieder hinzu
         report_to = sft_kwargs.pop("report_to", None)
 
+        checkpoint_dir = config.checkpoint_config.checkpoint_dir.format(base=base_path)
+        logging_dir = f"{checkpoint_dir}/logs"
+
         # 4) SFTConfig initialisieren
         args = SFTConfig(
-            output_dir=str(config.checkpoint_config.checkpoint_dir),
+            output_dir=checkpoint_dir,
             run_name=config.run_name,
             report_to=report_to,
             bf16=True,
@@ -46,7 +58,8 @@ class FullFineTuning(FineTuningMethod):
             save_strategy="epoch",
             save_total_limit=1,
             logging_strategy="steps",
-            logging_steps=50, # für wandb graphen 
+            logging_steps=50,  # für wandb graphen
+            logging_dir=logging_dir,
             **sft_kwargs,
         )
 
@@ -61,24 +74,20 @@ class FullFineTuning(FineTuningMethod):
         trainer.train()
         self.logger.info("Finished full fine-tuning training. Saving model now...")
 
-
         # 6) Save with config metadata for traceability
-        save_dir = f"{config.checkpoint_config.checkpoint_dir}"
+        save_dir = checkpoint_dir
         os.makedirs(save_dir, exist_ok=True)
-        
-                
+
         # Save model
         trainer.save_model(save_dir)
-        
+
         # 7) push final model to hub
         if config.checkpoint_config.push_to_hub:
             trainer.push_to_hub()
-        
-        
-        # 8) save locally meta data  
-        self.save_training_metadata(config.checkpoint_config.checkpoint_dir, self.model_adapter.get_name())
-        self.logger.info("Model and metadata saved. Successfully trained model.")
 
+        # 8) save locally meta data
+        self.save_training_metadata(checkpoint_dir, self.model_adapter.get_name())
+        self.logger.info("Model and metadata saved. Successfully trained model.")
 
         return model
 
@@ -91,11 +100,11 @@ class FullFineTuning(FineTuningMethod):
         # wenn du PEFT benutzt:
         try:
             from peft import PeftConfig, PeftModel
+
             peft_cfg = PeftConfig.from_pretrained(checkpoint_path)
             base = AutoModelForCausalLM.from_pretrained(peft_cfg.base_model_name_or_path)
             peft = PeftModel.from_pretrained(base, checkpoint_path)
             return peft.merge_and_unload()
         except ImportError:
             # reines HF-Model
-            from transformers import AutoModelForCausalLM
             return AutoModelForCausalLM.from_pretrained(checkpoint_path)

--- a/pipeline/safe_llm_finetune/scripts/train.py
+++ b/pipeline/safe_llm_finetune/scripts/train.py
@@ -21,37 +21,34 @@ from safe_llm_finetune.utils.logging import setup_logging
 
 def parse_args():
     p = argparse.ArgumentParser("Full SFT launcher")
-    p.add_argument("--run_name",       type=str, default=None,
-                   help="Name des Runs in W&B")
-    p.add_argument("--max_length",     type=int, default=1024,
-                   help="Maximale Token-Länge pro Sequenz")
-    p.add_argument("--batch_size",     type=int, default=2,
-                   help="Batch-Größe pro GPU")
-    p.add_argument("--learning_rate", "-lr",
-                   type=float, default=5e-5,
-                   help="Start-Learning-Rate")
-    p.add_argument("--warmup_steps",
-                   type=int, default=0,
-                   help="Anzahl Warmup-Schritte")
-    p.add_argument("--model_name",     type=str, required=True,
-                   help="z. B. google/gemma-3-1B-it")
-    p.add_argument("--out",            type=str, default="runs/tmp",
-                   help="Ausgabeverzeichnis für Checkpoints/Final-Model")
-    p.add_argument("--epochs",         type=int, default=1,
-                   help="Anzahl Trainingsepochen")
-    p.add_argument("--sample_size",
-                   type=lambda x: None if x.lower()=="none" else int(x),
-                   default=None,
-                   help="Number of samples (int) oder None für alle")
+    p.add_argument("--run_name", type=str, default=None, help="Name des Runs in W&B")
+    p.add_argument("--max_length", type=int, default=1024, help="Maximale Token-Länge pro Sequenz")
+    p.add_argument("--batch_size", type=int, default=2, help="Batch-Größe pro GPU")
+    p.add_argument("--learning_rate", "-lr", type=float, default=5e-5, help="Start-Learning-Rate")
+    p.add_argument("--warmup_steps", type=int, default=0, help="Anzahl Warmup-Schritte")
+    p.add_argument("--model_name", type=str, required=True, help="z. B. google/gemma-3-1B-it")
+    p.add_argument(
+        "--out",
+        type=str,
+        default="runs/tmp",
+        help="Ausgabeverzeichnis für Checkpoints/Final-Model",
+    )
+    p.add_argument("--epochs", type=int, default=1, help="Anzahl Trainingsepochen")
+    p.add_argument(
+        "--sample_size",
+        type=lambda x: None if x.lower() == "none" else int(x),
+        default=None,
+        help="Number of samples (int) oder None für alle",
+    )
     return p.parse_args()
 
 
 def main():
     setup_logging()
-    
+
     logger = logging.getLogger(__name__)
     logger.info("Starting model training pipeline")
-    
+
     args = parse_args()
 
     # 1) Datensatz vorbereiten
@@ -70,8 +67,8 @@ def main():
         learning_rate=args.learning_rate,
         warmup_steps=args.warmup_steps,
         max_seq_length=args.max_length,
-        report_to="wandb",                     # aktiviert W&B-Logging
-        run_name=args.run_name,                # Lauf-Name in W&B
+        report_to="wandb",  # aktiviert W&B-Logging
+        run_name=args.run_name,  # Lauf-Name in W&B
         checkpoint_config=CheckpointConfig(
             checkpoint_dir=pathlib.Path(args.out),
             save_strategy="epoch",
@@ -80,9 +77,10 @@ def main():
     )
 
     # 4) Voll-Fine-Tuning starten
-    FullFineTuning(ma).train(ds, cfg)
-    
+    FullFineTuning(ma).train(ds, cfg, pathlib.Path(args.out))
+
     logger.info("Pipeline completed successfully")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- update `FullFineTuning.train` to accept `base_path` and format checkpoint/log dirs
- update CLI training script to pass `base_path`
- clean up unused imports and fix lint issues

## Testing
- `ruff format --check pipeline/safe_llm_finetune/fine_tuning/methods/supervised_full_fine_tuning.py pipeline/safe_llm_finetune/scripts/train.py`
- `ruff check pipeline/safe_llm_finetune/fine_tuning/methods/supervised_full_fine_tuning.py pipeline/safe_llm_finetune/scripts/train.py`
- `python -m pytest tests` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c19e9539c833086035dd8fe665e4f