### PR TITLE
Fix docstring parameter name

### DIFF
--- a/pipeline/safe_llm_finetune/fine_tuning/base.py
+++ b/pipeline/safe_llm_finetune/fine_tuning/base.py
@@ -182,10 +182,10 @@ class FineTuningMethod(ABC):
     def save_training_metadata(self, checkpoint_path: str, model_name: str, **kwargs):
         """
         Save metadata about the training method used.
-        
+
         Args:
             checkpoint_path: Path to checkpoint
-            training_method: Name of training method
+            model_name: Name of the base model
             **kwargs: Additional metadata to save
         """
         metadata = {


### PR DESCRIPTION
## Summary
- update the `save_training_metadata` docstring to describe `model_name`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'safe_llm_finetune')*

------
https://chatgpt.com/codex/tasks/task_e_685173dbb05083309edc36488d30dafd