### PR TITLE
Free GPU memory after each evaluator

### DIFF
--- a/pipeline/safe_llm_finetune/evaluation/eval_analysis.py
+++ b/pipeline/safe_llm_finetune/evaluation/eval_analysis.py
@@ -10,6 +10,8 @@ import tempfile
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
+import torch
+
 from inspect_ai.log import EvalLog
 import pandas as pd
 from transformers import PreTrainedModel
@@ -135,6 +137,9 @@ def evaluate_model_and_checkpoint(
                     
             except Exception as e:
                 logger.error(f"Error running evaluation {evaluator.get_name()}: {str(e)}")
+
+            # Free GPU memory after each evaluator
+            torch.cuda.empty_cache()
     
     return results
 


### PR DESCRIPTION
## Summary
- import torch in `eval_analysis.py`
- empty CUDA cache after each evaluator

## Testing
- `ruff format --check pipeline/safe_llm_finetune/evaluation/eval_analysis.py`
- `ruff check pipeline/safe_llm_finetune/evaluation/eval_analysis.py`
- `make test` *(fails: file or directory not found: tests)*

------
https://chatgpt.com/codex/tasks/task_e_68518360c4cc8330ba25729a658b9c84