### PR TITLE
Fix checkpoint path type

### DIFF
--- a/pipeline/safe_llm_finetune/scripts/train.py
+++ b/pipeline/safe_llm_finetune/scripts/train.py
@@ -70,7 +70,7 @@ def main():
         report_to="wandb",  # aktiviert W&B-Logging
         run_name=args.run_name,  # Lauf-Name in W&B
         checkpoint_config=CheckpointConfig(
-            checkpoint_dir=pathlib.Path(args.out),
+            checkpoint_dir=str(pathlib.Path(args.out)),
             save_strategy="epoch",
             save_total_limit=1,
         ),


### PR DESCRIPTION
## Summary
- fix checkpoint path type for `CheckpointConfig` in `train.py`

## Testing
- `make lint` *(fails: Failed to read notebooks/local_eval_test.ipynb)*
- `make test` *(fails: file or directory not found: tests)*

------
https://chatgpt.com/codex/tasks/task_e_6851835e1d588330b8f4acc4e0160e76