### PR TITLE
Add sampling and debug options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,17 @@ Testing different fine-tuning methods on benign data and evaluating model safety
 
 --------
 
+## Quick evaluation
+
+Use the new command line options in the training scripts to limit the amount of
+data processed. Each script accepts `--sample_size` to load only part of the
+training dataset and `--debug` or `--limit` to restrict the number of examples
+evaluated. For example:
+
+```bash
+python dpo_main.py --sample_size 0.1 --debug
+```
+
+This runs the pipeline on 10% of the data and evaluates only a small subset of
+the tasks, which is useful for faster experiments inside a Docker container.
+

--- a/pipeline/dpo_main.py
+++ b/pipeline/dpo_main.py
@@ -1,9 +1,12 @@
 from huggingface_hub import login
+import argparse
 import logging
 from pathlib import Path
 import sys
+
 # Add project root to Python path to enable imports from the package
 sys.path.append(str(Path.cwd().parent))
+
 from safe_llm_finetune.datasets.code_ultra_feedback import CodeUltraFeedback
 from safe_llm_finetune.fine_tuning.methods.dpo import DPOConfig, DPOFineTuning
 from safe_llm_finetune.fine_tuning.models.gemma_3_1B_it_adapter import Gemma_3_1B
@@ -17,7 +20,38 @@ from safe_llm_finetune.evaluation.multitaskbench import MultiTaskBench
 
 import os
 
+def parse_sample_size(value: str):
+    if value.lower() == "none":
+        return None
+    try:
+        if "." in value:
+            return float(value)
+        return int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(str(e))
+
+
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--sample_size",
+        type=parse_sample_size,
+        default="0.1",
+        help="Subset of the dataset (float 0-1 percentage, int number or 'None')",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Run evaluations in debug mode (uses only a few samples)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of examples per evaluation",
+    )
+    args = parser.parse_args()
+
     setup_logging()
         
     logger = logging.getLogger(__name__)
@@ -33,7 +67,7 @@ def main():
 
     dpo_config = DPOConfig()
     gemma_adapter = Gemma_3_1B()
-    code_ultra_feedback = CodeUltraFeedback(sample_size=600)
+    code_ultra_feedback = CodeUltraFeedback(sample_size=args.sample_size)
     dpo_fine_tuning = DPOFineTuning(model_adapter=gemma_adapter, dpo_config=dpo_config)
     checkpoint_config = CheckpointConfig()
     training_config = TrainingConfig(checkpoint_config=checkpoint_config)
@@ -47,7 +81,14 @@ def main():
     logger.info("Finished Training. Moving on to evals...")
     # Evaluation
 
-    results = evaluate([AirBench(), MultiTaskBench(), CodalBench()], dpo_fine_tuning, trained_model, base_path, gemma_adapter.get_name())
+    results = evaluate(
+        [AirBench(debug=args.debug), MultiTaskBench(debug=args.debug), CodalBench(debug=args.debug)],
+        dpo_fine_tuning,
+        trained_model,
+        base_path,
+        gemma_adapter.get_name(),
+        limit=args.limit,
+    )
     print(results)
 
     logger.info("Experiment run finished successfully!")

--- a/pipeline/lora_main.py
+++ b/pipeline/lora_main.py
@@ -1,4 +1,5 @@
 from huggingface_hub import login
+import argparse
 import logging
 from pathlib import Path
 import sys
@@ -17,7 +18,38 @@ from safe_llm_finetune.evaluation.multitaskbench import MultiTaskBench
 
 import os
 
+def parse_sample_size(value: str):
+    if value.lower() == "none":
+        return None
+    try:
+        if "." in value:
+            return float(value)
+        return int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(str(e))
+
+
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--sample_size",
+        type=parse_sample_size,
+        default="0.1",
+        help="Subset of the dataset (float 0-1 percentage, int number or 'None')",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Run evaluations in debug mode (uses only a few samples)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of examples per evaluation",
+    )
+    args = parser.parse_args()
+
     setup_logging()
         
     logger = logging.getLogger(__name__)
@@ -33,7 +65,7 @@ def main():
 
     lora_config = LoRAConfig()
     gemma_adapter = Gemma_3_1B()
-    code_ultra_feedback = CodeUltraFeedback(sample_size=600)
+    code_ultra_feedback = CodeUltraFeedback(sample_size=args.sample_size)
     lora_fine_tuning = LoRAFineTuning(model_adapter=gemma_adapter, lora_config=lora_config)
     checkpoint_config = CheckpointConfig()
     training_config = TrainingConfig(checkpoint_config=checkpoint_config)
@@ -47,7 +79,14 @@ def main():
     logger.info("Finished Training. Moving on to evals...")
     # Evaluation
 
-    results = evaluate([AirBench(), MultiTaskBench(), CodalBench()], lora_fine_tuning, trained_model, base_path, gemma_adapter.get_name())
+    results = evaluate(
+        [AirBench(debug=args.debug), MultiTaskBench(debug=args.debug), CodalBench(debug=args.debug)],
+        lora_fine_tuning,
+        trained_model,
+        base_path,
+        gemma_adapter.get_name(),
+        limit=args.limit,
+    )
     print(results)
 
     logger.info("Experiment run finished successfully!")

--- a/pipeline/qlora_main.py
+++ b/pipeline/qlora_main.py
@@ -1,4 +1,5 @@
 from huggingface_hub import login
+import argparse
 import logging
 from pathlib import Path
 import sys
@@ -17,7 +18,38 @@ from safe_llm_finetune.evaluation.multitaskbench import MultiTaskBench
 
 import os
 
+def parse_sample_size(value: str):
+    if value.lower() == "none":
+        return None
+    try:
+        if "." in value:
+            return float(value)
+        return int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(str(e))
+
+
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--sample_size",
+        type=parse_sample_size,
+        default="0.1",
+        help="Subset of the dataset (float 0-1 percentage, int number or 'None')",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Run evaluations in debug mode (uses only a few samples)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of examples per evaluation",
+    )
+    args = parser.parse_args()
+
     setup_logging()
         
     logger = logging.getLogger(__name__)
@@ -33,7 +65,7 @@ def main():
 
     qlora_config = QLoRAConfig()
     gemma_adapter = Gemma_3_1B()
-    code_ultra_feedback = CodeUltraFeedback(sample_size=600)
+    code_ultra_feedback = CodeUltraFeedback(sample_size=args.sample_size)
     qlora_fine_tuning = QLoRAFineTuning(model_adapter=gemma_adapter, qlora_config=qlora_config)
     checkpoint_config = CheckpointConfig()
     training_config = TrainingConfig(checkpoint_config=checkpoint_config)
@@ -47,10 +79,17 @@ def main():
     logger.info("Finished Training. Moving on to evals...")
     # Evaluation
 
-    results = evaluate([AirBench(), MultiTaskBench(), CodalBench()], qlora_fine_tuning, trained_model, base_path, gemma_adapter.get_name())
+    results = evaluate(
+        [AirBench(debug=args.debug), MultiTaskBench(debug=args.debug), CodalBench(debug=args.debug)],
+        qlora_fine_tuning,
+        trained_model,
+        base_path,
+        gemma_adapter.get_name(),
+        limit=args.limit,
+    )
     print(results)
 
     logger.info("Experiment run finished successfully!")
 
 if __name__ == "__main__":
-        main()
+    main()

--- a/pipeline/safe_llm_finetune/evaluation/base.py
+++ b/pipeline/safe_llm_finetune/evaluation/base.py
@@ -38,8 +38,14 @@ class Evaluator(ABC):
         """
         pass
 
-    def run_eval(self, model_path: str, tokenizer_path: str, base_path: str) -> list[EvalLog]:
-        """runs inpects inate eval() function
+    def run_eval(
+        self,
+        model_path: str,
+        tokenizer_path: str,
+        base_path: str,
+        limit: int | None = None,
+    ) -> list[EvalLog]:
+        """Run inspect-ai evaluation with optional dataset limit.
         
         Args:
             model (PreTrainedModel): loaded local model
@@ -53,10 +59,23 @@ class Evaluator(ABC):
         
         log_file_path = f"{base_path}/{self.get_name()}"
         if self.debug:
-            results = inspect_eval(tasks=task, model= "openai/gpt-4o-mini", log_dir= log_file_path, limit=10)
+            results = inspect_eval(
+                tasks=task,
+                model="openai/gpt-4o-mini",
+                log_dir=log_file_path,
+                limit=10 if limit is None else limit,
+            )
         else:
-            
-            results = inspect_eval(tasks=task, model="hf/local", model_args=dict(model_path=model_path, tokenizer_path=tokenizer_path), log_dir=log_file_path, fail_on_error=False, limit = 500, retry_on_error = 5, trace=False)
+            results = inspect_eval(
+                tasks=task,
+                model="hf/local",
+                model_args=dict(model_path=model_path, tokenizer_path=tokenizer_path),
+                log_dir=log_file_path,
+                fail_on_error=False,
+                limit=limit or 500,
+                retry_on_error=5,
+                trace=False,
+            )
         
         return results
     

--- a/pipeline/safe_llm_finetune/evaluation/eval_analysis.py
+++ b/pipeline/safe_llm_finetune/evaluation/eval_analysis.py
@@ -62,7 +62,8 @@ def evaluate_model_and_checkpoint(
     model: PreTrainedModel,
     base_path: str,
     model_name: str,
-    checkpoint_info: Optional[Tuple[str, int]] = None
+    checkpoint_info: Optional[Tuple[str, int]] = None,
+    limit: int | None = None,
 ) -> Dict[str, Any]:
     """
     Evaluate a model (either final or checkpoint) on all evaluations.
@@ -111,7 +112,12 @@ def evaluate_model_and_checkpoint(
             try:
                 logger.info(f"Running {evaluator.get_name()} on {model_name}")
         
-                eval_log = evaluator.run_eval(model_path=model_path, tokenizer_path=tokenizer_path, base_path=base_path)
+                eval_log = evaluator.run_eval(
+                    model_path=model_path,
+                    tokenizer_path=tokenizer_path,
+                    base_path=base_path,
+                    limit=limit,
+                )
                 
                 if isinstance(eval_log, tuple):
                     logger.info(f"Received tuple from {evaluator.get_name()} on {model_name}")
@@ -144,7 +150,14 @@ def evaluate_model_and_checkpoint(
     return results
 
 
-def evaluate(evals: List[Evaluator], fine_tuner: FineTuningMethod, model: PreTrainedModel, base_path : str, model_name: str) -> pd.DataFrame:
+def evaluate(
+    evals: List[Evaluator],
+    fine_tuner: FineTuningMethod,
+    model: PreTrainedModel,
+    base_path: str,
+    model_name: str,
+    limit: int | None = None,
+) -> pd.DataFrame:
     """
     Evaluate a fine-tuned model and all its checkpoints on a list of evaluations.
     
@@ -155,6 +168,7 @@ def evaluate(evals: List[Evaluator], fine_tuner: FineTuningMethod, model: PreTra
         checkpoint_dir: Path to checkpoint directory
         output_dir: Directory to save results
         model_name: name of the base model that got fine-tuned
+        limit: optional maximum number of examples per evaluation
         
     Returns:
         DataFrame of results (also saved as CSV)
@@ -172,11 +186,12 @@ def evaluate(evals: List[Evaluator], fine_tuner: FineTuningMethod, model: PreTra
     logger.info("Evaluating final model...")
     final_results = evaluate_model_and_checkpoint(
         evals=evals,
-        fine_tuner= fine_tuner,
+        fine_tuner=fine_tuner,
         model=model,
         model_name=model_name,
         base_path=base_path,
-        checkpoint_info=None
+        checkpoint_info=None,
+        limit=limit,
     )
     results_list.append(final_results)
     
@@ -196,7 +211,8 @@ def evaluate(evals: List[Evaluator], fine_tuner: FineTuningMethod, model: PreTra
             model=None,  # Will be loaded from checkpoint
             model_name=model_name,
             base_path=base_path,
-            checkpoint_info=checkpoint_info
+            checkpoint_info=checkpoint_info,
+            limit=limit,
         )
         results_list.append(checkpoint_results)
         


### PR DESCRIPTION
## Summary
- expose `--sample_size`, `--debug`, and new `--limit` arguments in training scripts
- allow custom evaluation limit in `Evaluator.run_eval`
- propagate limit through `eval_analysis.evaluate`
- document quick evaluation options in README

## Testing
- `make lint` *(fails: Failed to read notebooks/*.ipynb)*
- `make test` *(fails: file or directory not found: tests)*

------
https://chatgpt.com/codex/tasks/task_e_6855744727788330bcb41194195911ed