### PR TITLE
Fix pandas requirement for Python 3.13

### DIFF
--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,6 +1,6 @@
 # Core data science and machine learning
 numpy>=1.26
-pandas==1.5
+pandas>=1.5
 scikit-learn
 torch==2.7.0
 tqdm


### PR DESCRIPTION
## Summary
- loosen pandas pin in requirements so install succeeds under Python 3.13

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6855eadf77148330ad504a37adca04ad